### PR TITLE
Issue 32 upgrade update

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,8 @@ Commands:
     rm              remove a RPM from the yum repository
     rpm             pass through command-args to the RPM binary
     self            admin/internal operations for lbpkr
-    update          update RPMs from the yum repository
+    update          update RPMs from the yum repository (bump the release number)
+    upgrade         upgrade RPMs from the yum repository (bump the version number)
     version         print out script version
 
 Use "lbpkr help <command>" for more information about a command.

--- a/cmd_update.go
+++ b/cmd_update.go
@@ -11,7 +11,7 @@ func lbpkr_make_cmd_update() *commander.Command {
 	cmd := &commander.Command{
 		Run:       lbpkr_run_cmd_update,
 		UsageLine: "update [options]",
-		Short:     "update RPMs from the yum repository",
+		Short:     "update RPMs from the yum repository (bump the release number)",
 		Long: `
 update updates RPMs from the yum repository.
 
@@ -52,6 +52,7 @@ func lbpkr_run_cmd_update(cmd *commander.Command, args []string) error {
 		EnableDryRun(dry),
 		EnableNoDeps(nodeps),
 		EnableJustDb(justdb),
+		EnablePackageMode(InstallMode|UpdateMode),
 	)
 	if err != nil {
 		return err

--- a/pkg.go
+++ b/pkg.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"github.com/lhcb-org/lbpkr/yum"
+)
+
+type Package struct {
+	*yum.Package
+	Mode Mode
+}
+
+type PackagesByDepGraph struct {
+	ctx  *Context
+	pkgs []Package
+}
+
+func (p PackagesByDepGraph) Len() int {
+	return len(p.pkgs)
+}
+
+func (p PackagesByDepGraph) Swap(i, j int) {
+	p.pkgs[i], p.pkgs[j] = p.pkgs[j], p.pkgs[i]
+}
+
+func (p PackagesByDepGraph) Less(i, j int) bool {
+	pi := p.pkgs[i]
+	pj := p.pkgs[j]
+
+	// check whether package 'i' (or one of its deps) needs 'j'
+	di, err := p.ctx.yum.RequiredPackages(pi.Package, -1)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, ii := range di {
+		if ii.RPMName() == pj.RPMName() {
+			// i (or one of its deps) needs package 'j'
+			// so correct order is: j <= i
+			return false
+		}
+	}
+
+	if true {
+		return true
+	}
+
+	pir, err := p.ctx.getNotInstalledPackageDeps(pi)
+	if err != nil {
+		panic(err)
+	}
+
+	pjr, err := p.ctx.getNotInstalledPackageDeps(pj)
+	if err != nil {
+		panic(err)
+	}
+
+	// i deps do not overlap with j.
+	// order by un-installed dependencies
+	return len(pir) < len(pjr)
+}


### PR DESCRIPTION
fix #32 

- introduce `main.Package` to bundle a package's intended installation mode
- install `RPM`s in 2 stages: first the updates (release-number bump) and then the installs (new packages)
- allow upgrades (version-number bump) only for the `lbpkr` `RPM` package
- test `upgrade`/`update` with `TestUpdateNotUpgrade`