### PR TITLE
Changed source for gographviz

### DIFF
--- a/cmd_dep_graph.go
+++ b/cmd_dep_graph.go
@@ -5,7 +5,7 @@ import (
 	"io/ioutil"
 	"strconv"
 
-	graph "code.google.com/p/gographviz"
+	graph "github.com/awalterschulze/gographviz"
 	"github.com/gonuts/commander"
 	"github.com/gonuts/flag"
 	"github.com/lhcb-org/lbpkr/yum"

--- a/lhcbconfig.go
+++ b/lhcbconfig.go
@@ -185,5 +185,34 @@ func (cfg *lhcbConfig) InitYum(ctx *Context) error {
 		}
 	}
 
+	// lhcb incubator
+	{
+		repo := filepath.Join(repodir, "lhcbincubator.repo")
+		f, err := os.Create(repo)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		err = ctx.writeYumRepo(f, map[string]string{
+			"name": "lhcbincubator",
+			"url":  repourl + "/incubator",
+		})
+		if err != nil {
+			return err
+		}
+
+		err = f.Sync()
+		if err != nil {
+			return err
+		}
+
+		err = f.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	
 	return err
 }


### PR DESCRIPTION
It looks like gographviz has moved.
If I understand correctly code.google.com is clsoing.
